### PR TITLE
Move ember-cli-moment-shim to dev dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ Installation
 ember install ember-power-calendar-moment
 ```
 
+This addon depends on `moment` package. If you use ember-auto-import, make sure that `moment` is
+in your `dependencies`.
+
+Alternatively, you can use shim package: `ember install ember-cli-moment-shim`
 
 Usage
 ------------------------------------------------------------------------------

--- a/package.json
+++ b/package.json
@@ -22,8 +22,7 @@
   },
   "dependencies": {
     "broccoli-funnel": "^2.0.2",
-    "ember-cli-babel": "^7.7.3",
-    "ember-cli-moment-shim": "^3.7.1"
+    "ember-cli-babel": "^7.7.3"
   },
   "devDependencies": {
     "broccoli-asset-rev": "^3.0.0",
@@ -33,6 +32,7 @@
     "ember-cli-htmlbars": "^3.0.1",
     "ember-cli-htmlbars-inline-precompile": "^2.1.0",
     "ember-cli-inject-live-reload": "^2.0.1",
+    "ember-cli-moment-shim": "^3.7.1",
     "ember-cli-qunit": "^4.4.0",
     "ember-cli-sass": "^10.0.0",
     "ember-cli-sri": "^2.1.0",


### PR DESCRIPTION
This allows using `ember-auto-import` for those who don't want to use the shim addon.

Let me know if documentation is not clear enough. This would be a breaking change.