### PR TITLE
Use moment format when setting calendar day numbers

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -98,6 +98,7 @@ export function normalizeMultipleActionValue(val) {
 
 export function normalizeCalendarDay(day) {
   day.moment = moment(day.date);
+  day.number = moment(day.date).date()
   return day;
 }
 

--- a/addon/index.js
+++ b/addon/index.js
@@ -98,7 +98,7 @@ export function normalizeMultipleActionValue(val) {
 
 export function normalizeCalendarDay(day) {
   day.moment = moment(day.date);
-  day.number = moment(day.date).date()
+  day.number = moment(day.date).date();
   return day;
 }
 


### PR DESCRIPTION
Fixes https://github.com/cibernox/ember-power-calendar/issues/237

Uses moment's date() to set the correct calendar number based on the timezone.