### PR TITLE
feat: test currentMonth through dateLibrary

### DIFF
--- a/ember-power-calendar-moment/src/index.ts
+++ b/ember-power-calendar-moment/src/index.ts
@@ -53,7 +53,6 @@ export default {
   localeStartOfWeek,
   startOfWeek,
   endOfWeek,
-  isCurrentMonth,
 };
 
 export function add(date: Date, quantity: number, unit: string): Date {

--- a/ember-power-calendar-moment/src/index.ts
+++ b/ember-power-calendar-moment/src/index.ts
@@ -53,6 +53,7 @@ export default {
   localeStartOfWeek,
   startOfWeek,
   endOfWeek,
+  isCurrentMonth,
 };
 
 export function add(date: Date, quantity: number, unit: string): Date {
@@ -244,4 +245,8 @@ export function endOfWeek(day: Date, startOfWeek: number): Date {
     day = add(day, 1, 'day');
   }
   return day;
+}
+
+export function isCurrentMonth(date: Date): boolean {
+  return moment(date).month() === moment().month();
 }

--- a/ember-power-calendar-moment/src/index.ts
+++ b/ember-power-calendar-moment/src/index.ts
@@ -172,6 +172,7 @@ export function normalizeMultipleActionValue(val: {
 export function normalizeCalendarDay(day: PowerCalendarDay): PowerCalendarDay {
   day.moment = moment(day.date);
   day.number = moment(day.date).date();
+  day.isCurrentMonth = moment(day.date).month() === moment().month();
   return day;
 }
 
@@ -245,8 +246,4 @@ export function endOfWeek(day: Date, startOfWeek: number): Date {
     day = add(day, 1, 'day');
   }
   return day;
-}
-
-export function isCurrentMonth(date: Date): boolean {
-  return moment(date).month() === moment().month();
 }


### PR DESCRIPTION
Nowadays we rely on JavaScript dates when checking whether or not a day belongs to the same month. Which leads us to a problem, because depending on the timezone configured, we can jump or be behind by a day.

However, when using [momentjs.com/timezone/](https://momentjs.com/timezone/), it is necessary to rely on dateLibrary (an abstraction that inverts the control of the date library - in this case moment), to obtain the currentMonth instead of using the JavaScript date.

Hence, it's necessary to add the method below, at the end of [addon/utils.js](https://github.com/cibernox/ember-power-calendar/blob/master/ember-power-calendar/src/utils.ts).

```js
export function isCurrentMonth(day) {
  return getDateLibrary().isCurrentMonth(day);
}
```

So, we can replace [this line](https://github.com/cibernox/ember-power-calendar/blob/5f3d74987309171bae7e79aed70890aa44d609f0/addon/components/power-calendar/days.js#L188) with this code below:

```js
isCurrentMonth: isCurrentMonth(date),
```