### PR TITLE
Revert "feat: test currentMonth through dateLibrary"

### DIFF
--- a/ember-power-calendar-moment/src/index.ts
+++ b/ember-power-calendar-moment/src/index.ts
@@ -171,7 +171,6 @@ export function normalizeMultipleActionValue(val: {
 export function normalizeCalendarDay(day: PowerCalendarDay): PowerCalendarDay {
   day.moment = moment(day.date);
   day.number = moment(day.date).date();
-  day.isCurrentMonth = moment(day.date).month() === moment().month();
   return day;
 }
 


### PR DESCRIPTION
@mkszepp my apologies but we should revert cibernox/ember-power-calendar-moment#63.

I made a mistake when testing the month relative to the day with the current month in the real world.

It is always comparing with the current month in the real world. 
When we change months in the calendar, we are changing the center. Therefore, any month outside the current month would have `isCurrentMonth` as false.

To achieve the same result as the original PR was looking for, I'm going to create a new PR against ember-power-calendar with the following change:

```js
  return normalizeCalendarDay({
    id,
    number: date.getDate(),
    date: new Date(date),
    isDisabled: isDisabled,
    isFocused: focusedId === id,
    isCurrentMonth: isSame(date, currentCenter, 'month'), //using `isSame` resource already provided.
    isToday: isSame(date, today, 'day'),
    isSelected: dayIsSelected(date, calendar),
  } as PowerCalendarDay);
```

Instead of this code: 
https://github.com/cibernox/ember-power-calendar/blob/50e641baa16bed5423b8eb3813ebeaccc50b9b81/ember-power-calendar/src/-private/days-utils.ts#L191

Again, my apologies for that.