### PR TITLE
Remove incorrect `import 'moment';`

### DIFF
--- a/ember-power-calendar-moment/src/index.ts
+++ b/ember-power-calendar-moment/src/index.ts
@@ -9,7 +9,7 @@ import type {
   NormalizeRangeActionValue,
   PowerCalendarDay,
 } from 'ember-power-calendar/utils';
-import * as momentNs from 'moment';
+import type * as momentNs from 'moment';
 import type { DurationInputArg2, unitOfTime } from 'moment';
 
 const moment: typeof momentNs = (() => {


### PR DESCRIPTION
We have `import 'moment';` on npm which is not corectly... its just for typing

![grafik](https://github.com/user-attachments/assets/50a5b780-fcdb-43ca-bbde-ad722967f885)

This bug is in all versions (since v1)